### PR TITLE
[Refactor] Zustand를 사용한 전역 인증 상태 관리 도입

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.9.5",
         "sass": "^1.93.2",
-        "vite-plugin-svgr": "^4.5.0"
+        "vite-plugin-svgr": "^4.5.0",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -3624,7 +3625,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4296,7 +4297,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -8558,6 +8559,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.9.5",
     "sass": "^1.93.2",
-    "vite-plugin-svgr": "^4.5.0"
+    "vite-plugin-svgr": "^4.5.0",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.37.0",

--- a/src/apis/utils/instance.js
+++ b/src/apis/utils/instance.js
@@ -1,11 +1,12 @@
 import axios from 'axios';
+import useAuthStore from '../../store/authStore';
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 // ===== 공통 요청 인터셉터
 const onRequestFulfilled = (config) => {
-  // localStorage에서 토큰 가져오기
-  const accessToken = localStorage.getItem('accessToken');
+  // 스토어에서 토큰 가져오기
+  const { accessToken } = useAuthStore.getState();
 
   // 토큰이 있다면 헤더에 추가
   if (accessToken) {
@@ -29,7 +30,11 @@ const onResponseRejected = (error) => {
 
   if (response?.status === 401) {
     console.error('401 Unauthorized: 토큰이 만료되었거나 유효하지 않습니다.');
-    window.location.href = '/login';
+    useAuthStore.getState().logout(); // 스토어 비우기
+
+    if (window.location.pathname !== '/login') {
+      window.location.href = '/login';
+    }
   }
 
   return Promise.reject(error);

--- a/src/pages/loginPage/LoginPage.jsx
+++ b/src/pages/loginPage/LoginPage.jsx
@@ -9,9 +9,11 @@ import AuthBox from '@components/authBox/AuthBox';
 import Footer from './components/Footer';
 import { CheckIcon, CheckFillIcon } from './components/icon/index';
 import AuthButton from '../../components/AuthButton';
+import useAuthStore from '../../store/authStore';
 
 const LoginPage = () => {
   const { goTo } = useNavigation();
+  const login = useAuthStore((state) => state.login);
 
   const savedEmail = localStorage.getItem('savedEmail') || '';
 
@@ -37,8 +39,9 @@ const LoginPage = () => {
       // setLoading(true);
       const result = await loginUserApi(form);
       console.log('로그인 성공', result);
-      // 액세스 토큰 저장
-      localStorage.setItem('accessToken', result.access_token);
+      // 스토어에 액세스 토큰 저장
+      login(result.access_token, result.user);
+
       // 이메일 저장
       if (form.remember_id) {
         localStorage.setItem('savedEmail', form.email.trim());

--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+const useAuthStore = create(
+  persist(
+    (set) => ({
+      accessToken: null,
+      user: null, // 사용자 정보
+      isLoggedIn: false,
+
+      // 로그인 액션
+      login: (token, userData) => {
+        set({ accessToken: token, user: userData, isLoggedIn: true });
+      },
+
+      // 로그아웃 액션
+      logout: () => {
+        set({ accessToken: null, user: null, isLoggedIn: false });
+        // localStorage도 자동으로 비워줌
+      },
+
+      // 사용자 정보 업데이트
+      setUser: (userData) => {
+        set({ user: userData });
+      },
+    }),
+    {
+      name: 'auth-storage', // localStorage에 저장될 키 이름
+    },
+  ),
+);
+
+export default useAuthStore;


### PR DESCRIPTION
## 📝 Work Description
<!-- 작업한 내용을 모두 작성해 주세요. -->
- 기존 `localStorage`를 직접 제어하던 방식의 인증 로직을 `Zustand`를 사용한 전역 상태 관리 방식으로 변경
- Zustand 스토어 신규 생성 (`src/store/authStore.js`)
- `persist` 미들웨어를 사용하여 스토어 상태를 `localStorage` (`auth-storage` 키)에 자동으로 저장
- `login`, `logout` 액션을 정의 -> 나중에 로그아웃 버튼에 연결하면 됩니당
- API 요청 시 `localStorage.getItem('accessToken')` 대신 `useAuthStore.getState().accessToken`을 사용하도록 수정(`src/apis/instance.js`)

## 🚨 Notice
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- 로그인 성공 시 `localStorage.setItem`을 직접 호출하는 대신, `useAuthStore`의 `login` 액션을 호출하여 상태를 업데이트하도록 변경
- 로그인 후 F12 `Application` 탭 -> `localStorage`에 `auth-storage` 키가 생성되고 토큰이 저장되는지 확인 바랍니다

## #️⃣ Related Issue
<!-- 연관된 이슈를 태그해 주세요. -->
- close #57 
  
## 👀 ScreenShot
<!-- 결과 이미지를 첨부해 주세요. -->
